### PR TITLE
Fix typo in container registry domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ tag: ## Tag git repo
 
 build: ## Build Docker image
 	echo "[${version}]"
-	docker build --tag ghrc.io/thinkinglabs/terraform:${version} .
+	docker build --tag ghcr.io/thinkinglabs/terraform:${version} .
 
 help:
 	@grep -h -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
Hi `thinkinglabs/docker-terraform`!

This is not an automatic, 🤖-generated PR, as you can check in my [GitHub profile](https://github.com/p-), I work for GitHub and I am part of the [GitHub Security Lab](https://securitylab.github.com/).

While performing a code search for container registry domains we noticed that this repo contains a misspelled domain name.

If a malicious actor were in control of that misspelled domain, they could potentially perform an attack on the software supply chain of this project and/or steal the credentials used to connect to the container registry (depending on how the misspelled domain name of the container registry is used).
Please fix this typo and check your documentation for similar typos.